### PR TITLE
Allow reordering sidebar links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.398</version>
+        <version>1.447</version>
     </parent>
 
     <artifactId>sidebar-link</artifactId>

--- a/src/main/resources/hudson/plugins/sidebar_link/links.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/links.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <!-- l:header does not work here -->
   <style type="text/css"> table.sidebar_link td { vertical-align:middle; } </style>
-  <f:repeatable var="link" items="${attrs.links}" name="links" add="${%Add Link}">
+  <f:repeatable var="link" items="${attrs.links}" name="links" add="${%Add Link}" header="${%Sidebar Link}">
     <table class="sidebar_link">
       <f:entry title="${%Link URL}" help="/plugin/sidebar-link/help-url.html">
         <f:textbox name="urlName" value="${link.urlName}"/>


### PR DESCRIPTION
Changed Jenkins version because of `java.lang.NoClassDefFoundError: com/sun/mirror/apt/AnnotationProcessorFactory`.
