### PR TITLE
[FIXED JENKINS-15924] Fix issues with empty link list in job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.398</version>
+        <version>1.554.3</version>
     </parent>
 
     <artifactId>sidebar-link</artifactId>

--- a/src/main/java/hudson/plugins/sidebar_link/ProjectLinks.java
+++ b/src/main/java/hudson/plugins/sidebar_link/ProjectLinks.java
@@ -44,7 +44,9 @@ public class ProjectLinks extends JobProperty<AbstractProject<?,?>> {
 
     @DataBoundConstructor
     public ProjectLinks(List<LinkAction> links) {
-        this.links = links;
+        if (links != null) {
+            this.links = links;
+        }
     }
 
     public List<LinkAction> getLinks() { return links; }
@@ -52,6 +54,13 @@ public class ProjectLinks extends JobProperty<AbstractProject<?,?>> {
     @Override
     public Collection<? extends Action> getJobActions(AbstractProject<?,?> job) {
         return links;
+    }
+
+    private Object readResolve() {
+        if (links == null) {
+            links = new ArrayList<LinkAction>();
+        }
+        return this;
     }
 
     @Extension


### PR DESCRIPTION
- Don't allow saving a null list of links (no links)
- readResolve() fix existing broken configurations
