### PR TITLE
[FIXED JENKINS-24124] Add sidebar links for Computers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.398</version>
+        <version>1.554.3</version>
     </parent>
 
     <artifactId>sidebar-link</artifactId>

--- a/src/main/java/hudson/plugins/sidebar_link/ComputerLinkFactory.java
+++ b/src/main/java/hudson/plugins/sidebar_link/ComputerLinkFactory.java
@@ -1,0 +1,34 @@
+package hudson.plugins.sidebar_link;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Node;
+import jenkins.model.TransientActionFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Extension
+public class ComputerLinkFactory extends TransientActionFactory<Computer> {
+
+    @Override
+    public Class<Computer> type() {
+        return Computer.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Computer target) {
+        Node node = target.getNode();
+        if (node == null) {
+            return new ArrayList<LinkAction>();
+        }
+
+        NodeLinks prop = node.getNodeProperties().get(NodeLinks.class);
+        if (prop == null) {
+            return new ArrayList<LinkAction>();
+        }
+
+        return prop.getLinks();
+    }
+}

--- a/src/main/java/hudson/plugins/sidebar_link/NodeLinks.java
+++ b/src/main/java/hudson/plugins/sidebar_link/NodeLinks.java
@@ -1,0 +1,39 @@
+package hudson.plugins.sidebar_link;
+
+import hudson.Extension;
+import hudson.model.*;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NodeLinks extends NodeProperty<Slave> {
+    private List<LinkAction> links = new ArrayList<LinkAction>();
+
+    @DataBoundConstructor
+    public NodeLinks(List<LinkAction> links) {
+        if (links != null) {
+            this.links = links;
+        }
+    }
+
+    public List<LinkAction> getLinks() { return links; }
+
+    private Object readResolve() {
+        if (links == null) {
+            links = new ArrayList<LinkAction>();
+        }
+        return this;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends NodePropertyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Sidebar Links";
+        }
+    }
+
+}

--- a/src/main/resources/hudson/plugins/sidebar_link/NodeLinks/config.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/NodeLinks/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+    <f:entry>
+        <sl:links links="${instance.links}"/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
Use of `TransientActionFactory` requires at least 1.548. Cannot use `TransientComputerActionFactory` as it [never updates](https://github.com/jenkinsci/jenkins/commit/a2e597b3ee34ea0463bcb717a477019a737d9922).
