### PR TITLE
[JENKINS-45451] url field not populated fix

### DIFF
--- a/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
+++ b/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
@@ -74,7 +74,7 @@ public class LinkAction implements Action {
     public String getIconFileName() { return icon; }
     
     @Restricted(NoExternalUse.class)
-    public String getUnprotectedLink() {
+    public String getUnprotectedUrlName() {
         return url;
     }
     


### PR DESCRIPTION
[JENKINS-45451](https://issues.jenkins-ci.org/browse/JENKINS-45451). Fixes small typo from security patch. Prevented the url field from being populated on the project config page.

@reviewbybees @oleg-nenashev 