### PR TITLE
JENKINS-55710, #28 - Fix icon upload iframe in global config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,12 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-                <filtering>true</filtering>
+
+                <!-- Disable resource filtering because *.jelly files contain
+                     syntax like "${url}" that should refer to Jelly variables
+                     at run time, rather than be replaced with POM properties
+                     at build time.  -->
+                <filtering>false</filtering>
             </resource>
         </resources>
     </build>

--- a/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/config.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/config.jelly
@@ -6,7 +6,7 @@
       <sl:links links="${it.links}"/>
     </f:entry>
     <f:entry>
-      <j:set var="url" value="${rootURL}/plugin/sidebar-link/startUpload"/>
+      <j:set var="url" value="${rootURL}/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/startUpload"/>
       <iframe src="${url}" frameborder="0" style="width:100%;height:4em;margin-top:2em">
         <a href="${url}" target="_blank">${%Upload image file...}</a>
       </iframe>

--- a/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/startUpload.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/startUpload.jelly
@@ -1,12 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:ajax>
-  <html>
-    <head>
-      <link rel="stylesheet" href="${resURL}/css/style.css" type="text/css" />
-      <link rel="stylesheet" href="${resURL}/css/color.css" type="text/css" />
-    </head>
-    <body>
+  <l:layout title="${%Upload image file}" type="full-screen">
+    <l:main-panel>
       <form method="post" action="upload" enctype="multipart/form-data">
         <span class="setting-name">${%Upload an image file:}</span>
         <input type="file" name="linkimage.file" size="40"/>
@@ -15,7 +10,6 @@
         <br/>
         <span class="setting-description">${%Image should be square; will be rendered as 24x24.}</span>
       </form>
-    </body>
-  </html>
-</l:ajax>
+    </l:main-panel>
+  </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/startUpload.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/startUpload.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%Upload image file}" type="full-screen">
     <l:main-panel>
-      <form method="post" action="upload" enctype="multipart/form-data">
+      <form method="post" action="uploadLinkImage" enctype="multipart/form-data">
         <span class="setting-name">${%Upload an image file:}</span>
         <input type="file" name="linkimage.file" size="40"/>
         <st:nbsp/>


### PR DESCRIPTION
The icon upload feature of this plugin did not work, for several reasons:

1. [Maven resource filtering](<https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html> "Apache Maven Resources Plugin – Filtering") replaced `${url}` with `https://github.com/jenkinsci/sidebar-link-plugin` in `SidebarLinkPlugin/config.jelly` at build time, so the iframe pointed to GitHub and not to the Jenkins controller, and was blocked by Web browsers.
   This was reported in <https://github.com/jenkinsci/sidebar-link-plugin/issues/28>.
   ✅ Fix by disabling resource filtering.
2. Jenkins no longer maps `${rootURL}/plugin/sidebar-link/startUpload` to `startUpload.jelly` because <https://github.com/jenkinsci/sidebar-link-plugin/pull/25> made SidebarLinkPlugin extend GlobalConfiguration rather than Plugin.
   ✅ Fix by using `${rootURL}/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/startUpload` instead.
3. The upload POST failed with “HTTP ERROR 403 No valid crumb was included in the request”.
   This was reported in [JENKINS-55710](https://issues.jenkins.io/browse/JENKINS-55710).
   ✅ Fix by replacing [`<l:ajax>`](https://github.com/jenkinsci/sidebar-link-plugin/blob/63ef2a3a69edae7ee8d5d212e04b977c209c8aa7/src/main/resources/hudson/plugins/sidebar_link/SidebarLinkPlugin/startUpload.jelly#L3) with `<l:layout>`, which adds the [anti-CSRF crumb values](https://github.com/jenkinsci/jenkins/blob/8a29e8858b49da45c0071f690d4ceebe8db2f18f/core/src/main/resources/lib/layout/layout.jelly#L105) and [scripts](https://github.com/jenkinsci/jenkins/blob/8a29e8858b49da45c0071f690d4ceebe8db2f18f/core/src/main/resources/lib/layout/layout.jelly#L128).
4. `startUpload.jelly` had `action="upload"` but the method in SidebarLinkPlugin was renamed from `doUpload` to `doUploadLinkImage` in <https://github.com/jenkinsci/sidebar-link-plugin/pull/25>.
   ✅ Fix by using `action="uploadLinkImage"`.

Fix <https://github.com/jenkinsci/sidebar-link-plugin/issues/28> and [JENKINS-55710](https://issues.jenkins.io/browse/JENKINS-55710)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue