### PR TITLE
[JENKINS-68250] Fixes PNG help icon usage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <jenkins.version>2.332.2</jenkins.version>
-        <java.level>8</java.level>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.18</version>
+        <version>4.40</version>
     </parent>
 
     <artifactId>sidebar-link</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,68 +13,63 @@
     <url>https://github.com/jenkinsci/sidebar-link-plugin</url>
 
     <properties>
-        <jenkins.version>2.263.4</jenkins.version>
+        <jenkins.version>2.332.2</jenkins.version>
         <java.level>8</java.level>
-        <configuration-as-code.version>1.47</configuration-as-code.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1246.va_b_50630c1d19</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <!-- not to have
-             Failed while enforcing RequireUpperBoundDeps -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-json-org</artifactId>
-            <version>2.12.0</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.15</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.8.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>test-annotations</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.2</version>
+            <version>2.10.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20211205</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -107,7 +102,7 @@
       <developerConnection>scm:git:git@github.com:jenkinsci/sidebar-link-plugin.git</developerConnection>
       <url>https://github.com/jenkinsci/sidebar-link-plugin</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <repositories>
         <repository>
@@ -122,36 +117,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.hudson.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.17</version>
-            </plugin>
-        </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-
-                <!-- Disable resource filtering because *.jelly files contain
-                     syntax like "${url}" that should refer to Jelly variables
-                     at run time, rather than be replaced with POM properties
-                     at build time.  -->
-                <filtering>false</filtering>
-            </resource>
-        </resources>
-    </build>
 </project>

--- a/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
+++ b/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
@@ -65,7 +65,7 @@ public class LinkAction implements Action {
         }
 
         if(StringUtils.isBlank(iconFileName)) {
-            iconFileName = "static/efbf17e4/images/16x16/help.png";
+            iconFileName = "static/79e6e80a/images/svgs/help.svg";
         }
 
         this.url = urlName;

--- a/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
+++ b/src/main/java/hudson/plugins/sidebar_link/LinkAction.java
@@ -65,7 +65,7 @@ public class LinkAction implements Action {
         }
 
         if(StringUtils.isBlank(iconFileName)) {
-            iconFileName = "static/79e6e80a/images/svgs/help.svg";
+            iconFileName = "icon-help icon-md";
         }
 
         this.url = urlName;

--- a/src/test/java/hudson/plugins/sidebar_link/ProjectLinksTest.java
+++ b/src/test/java/hudson/plugins/sidebar_link/ProjectLinksTest.java
@@ -63,7 +63,7 @@ public class ProjectLinksTest {
         assertNotNull(sideBarLinkAction);
         assertEquals("http://example.com", sideBarLinkAction.getUrlName());
         assertEquals("Side Bar Example", sideBarLinkAction.getDisplayName());
-        assertEquals("static/efbf17e4/images/16x16/help.png", sideBarLinkAction.getIconFileName());
+        assertEquals("icon-help icon-md", sideBarLinkAction.getIconFileName());
     }
 
     @Test
@@ -94,6 +94,6 @@ public class ProjectLinksTest {
         LinkAction link = projectLinks.getLinks().get(0);
         assertEquals("http://example.com", link.getUrlName());
         assertEquals("Side Bar Example", link.getDisplayName());
-        assertEquals("static/efbf17e4/images/16x16/help.png", link.getIconFileName());
+        assertEquals("icon-help icon-md", link.getIconFileName());
     }
 }

--- a/src/test/java/hudson/plugins/sidebar_link/SidebarLinkPluginJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/sidebar_link/SidebarLinkPluginJCasCCompatibilityTest.java
@@ -16,7 +16,7 @@ public class SidebarLinkPluginJCasCCompatibilityTest extends RoundTripAbstractTe
         }
         SidebarLinkPlugin descriptor = jenkins.getDescriptorByType(SidebarLinkPlugin.class);
         descriptor.getLinks().forEach((temp) -> {
-            assertEquals("static/efbf17e4/images/16x16/help.png", temp.getIconFileName());
+            assertEquals("icon-help icon-md", temp.getIconFileName());
             assertEquals("testlink", temp.getDisplayName());
             assertEquals("www.none.com", temp.getUrlName());
         });


### PR DESCRIPTION
Fixes #40.
Comes with #42 and #41.

Using a recent enough version of Jenkins, the SVG files are already available, along side the PNG files. 
But, to prepare `2.333` and the PNG removal, we are now defaulting to the SVG help icon.

This won't solve the problem when users are setting the icon link to a PNG file bundled in core.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
