### PR TITLE
Enable incrementals for easier testing and bump baseline to 2.387.3

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.6</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -3,17 +3,20 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.53</version>
+        <version>4.65</version>
     </parent>
 
     <artifactId>sidebar-link</artifactId>
     <packaging>hpi</packaging>
     <name>Sidebar Link</name>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <url>https://github.com/jenkinsci/sidebar-link-plugin</url>
 
     <properties>
-        <java.level>11</java.level>
+        <jenkins.version>2.387.3</jenkins.version>
+        <revision>2.2.3</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/sidebar-link-plugin</gitHubRepo>
     </properties>
 
     <dependencyManagement>
@@ -22,8 +25,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2133.v2e6c00fe4d61</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,10 +37,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
@@ -98,10 +97,10 @@
     </description>
 
     <scm>
-      <connection>scm:git:git@github.com/jenkinsci/sidebar-link-plugin.git</connection>
-      <developerConnection>scm:git:git@github.com:jenkinsci/sidebar-link-plugin.git</developerConnection>
-      <url>https://github.com/jenkinsci/sidebar-link-plugin</url>
-      <tag>HEAD</tag>
+      <connection>scm:git:https@github.com/${gitHubRepo}.git</connection>
+      <developerConnection>scm:git:https@github.com:${gitHubRepo}.git</developerConnection>
+      <url>https://github.com/${gitHubRepo}</url>
+      <tag>${scmTag}</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
Incrementals is a must to test component between them

Bump baseline to 2.387.3 as all version bellow 2.361 don't receive bom update (https://github.com/jenkinsci/bom/releases/tag/2133.v2e6c00fe4d61)

Remove also unneeded dependencies when targeting Jenkins 2

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
