### PR TITLE
[JENKINS-71391] always validate fields

### DIFF
--- a/src/main/resources/hudson/plugins/sidebar_link/links.jelly
+++ b/src/main/resources/hudson/plugins/sidebar_link/links.jelly
@@ -5,13 +5,19 @@
     <f:repeatable var="link" items="${instance.links}" name="links" add="${%Add Link}" header="${%Sidebar Link}">
         <table class="sidebar_link">
             <f:entry title="${%Link URL}" help="/plugin/sidebar-link/help-url.html">
-                <f:textbox name="urlName" value="${link.unprotectedUrlName}" field="linkUrl"/>
+                <f:textbox name="urlName" value="${link.unprotectedUrlName}" field="linkUrl"
+                           checkUrl="${rootURL}/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/checkLinkUrl"
+                           checkDependsOn="" />
             </f:entry>
             <f:entry title="${%Link Text}">
-                <f:textbox name="displayName" value="${link.displayName}" field="linkText"/>
+                <f:textbox name="displayName" value="${link.displayName}" field="linkText"
+                           checkUrl="${rootURL}/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/checkLinkText"
+                           checkDependsOn="" />
             </f:entry>
             <f:entry title="${%Link Icon}" help="/plugin/sidebar-link/help-icon.html">
-                <f:textbox name="iconFileName" value="${link.iconFileName}" field="linkIcon"/>
+                <f:textbox name="iconFileName" value="${link.iconFileName}" field="linkIcon"
+                           checkUrl="${rootURL}/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/checkLinkIcon"
+                           checkDependsOn="" />
             </f:entry>
             <f:entry>
                 <f:repeatableDeleteButton/>


### PR DESCRIPTION
currently validation of the fields happens only for on the global configuration page of Jenkins.
With this change validation will happen also when configuring links on folders, projects and computers.

See [JENKINS-71391](https://issues.jenkins.io/browse/JENKINS-71391)

<!-- Please describe your pull request here. -->

### Testing done

Manually tested

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
