### PR TITLE
use https instead of git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </description>
 
     <scm>
-      <connection>scm:git:ssh://git@github.com/${gitHubRepo}.git</connection>
+      <connection>scm:git:https://git@github.com/${gitHubRepo}.git</connection>
       <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
       <url>https://github.com/${gitHubRepo}</url>
       <tag>${scmTag}</tag>


### PR DESCRIPTION
use https protocol instead of git protocol because Github is deprecating git protocol

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```
