### PR TITLE
Improve file validation

### DIFF
--- a/src/main/java/hudson/plugins/sidebar_link/SidebarLinkPlugin.java
+++ b/src/main/java/hudson/plugins/sidebar_link/SidebarLinkPlugin.java
@@ -151,7 +151,7 @@ public class SidebarLinkPlugin extends GlobalConfiguration {
 
         try {
             File jenkinsHomeDirectory = Jenkins.get().getRootDir();
-            String userContentDirectory = jenkinsHomeDirectory.getCanonicalPath() + File.separatorChar + "userContent";
+            String userContentDirectory = jenkinsHomeDirectory.getCanonicalPath() + File.separatorChar + "userContent" + File.separatorChar;
             File imageFile = new File(jenkinsHomeDirectory, value);
 
             String canonicalPath = imageFile.getCanonicalPath();


### PR DESCRIPTION
The filepath validation performed on the `doCheckLinkIcon` needed some improvement, it was still allowing to discover if a directory called `userContent[RandomString]` existed. Which I agree, is an edge case that will never happen in the real world.

To fix that, I simply added a file separator to the `userContent` definition to avoid this behavior.

### Testing done

Create a directory called `userContent2` at the same level as the `userContent` one and called: 

```
[JENKINS_INSTANCE]/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/checkLinkIcon?value=userContent2/[AnotherFile]
```

I also tested that it was still working for a correct usage, e.g:

```
[JENKINS_INSTANCE]/descriptorByName/hudson.plugins.sidebar_link.SidebarLinkPlugin/checkLinkIcon?value=userContent/readme.txt
```
