### PR TITLE
Make the "Back" link in the icon image upload dialog work with Jenkins 2.539+ CSP protection

### DIFF
--- a/src/main/java/hudson/plugins/sidebar_link/SidebarLinkPlugin.java
+++ b/src/main/java/hudson/plugins/sidebar_link/SidebarLinkPlugin.java
@@ -125,7 +125,7 @@ public class SidebarLinkPlugin extends GlobalConfiguration {
         rsp.setContentType("text/html");
         rsp.getWriter().println(
                 (error != null ? error : Messages.Uploaded("<code>/" + filename + "</code>"))
-                        + " <a href=\"javascript:history.back()\">" + Messages.Back() + "</a>");
+                        + " <a href=\"startUpload\">" + Messages.Back() + "</a>");
     }
 
     @Restricted(NoExternalUse.class)


### PR DESCRIPTION
Resolves https://github.com/jenkinsci/sidebar-link-plugin/issues/106.

Since this response is only served for a single URL, the back link can just specify the actual page URL, rather than needing to go back in history.

### Testing done

`mvn hpi:run -Djenkins.version=2.539`, then uploaded a file (or not) to get the response. Clicked the link.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
